### PR TITLE
Add example configuration

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+```sh
+docker-compose -f ndt.yml up
+```

--- a/examples/ndt.yml
+++ b/examples/ndt.yml
@@ -1,0 +1,111 @@
+version: '3.7'
+services:
+  ndt-server:
+    image: measurementlab/ndt-server:v0.20.20
+    volumes:
+      - ./certs:/certs
+      - ./html:/html
+      - ./schemas:/schemas
+      - ./resultsdir:/resultsdir
+    cap_drop:
+      - ALL
+    depends_on:
+      generate-schemas:
+        condition: service_completed_successfully
+      generate-uuid:
+        condition: service_completed_successfully
+
+    # NOTE: All containers will use the same network and IP. All ports
+    # must be configured on the first service.
+    ports:
+      # ndt-server TLS and non-TLS ports.
+      - target: 4443
+        published: 4443
+        protocol: tcp
+        mode: bridge
+      - target: 8080
+        published: 8080
+        protocol: tcp
+        mode: bridge
+      # ndt-server prometheus.
+      - target: 9990
+        published: 9990
+        protocol: tcp
+        mode: bridge
+      # jostler prometheus.
+      - target: 9991
+        published: 9991
+        protocol: tcp
+        mode: bridge
+    command:
+      - -uuid-prefix-file=/schemas/uuid.prefix
+      - -cert=/certs/cert.pem
+      - -key=/certs/key.pem
+      - -datadir=/resultsdir/ndt
+      - -ndt7_addr=:4443
+      - -ndt7_addr_cleartext=:8080
+      # Allow ndt7 data to be autoloaded.
+      - -compress-results=false
+      # TODO: confirm device name.
+      - -txcontroller.device=eth0
+      - -txcontroller.max-rate=150000000
+      - -prometheusx.listen-address=:9990
+      # Add server metadata.
+      - -label=type=virtual
+      - -label=deployment=byos
+      # TODO: add helpful server location metadata labels.
+      - -label=region=TODO
+      # Effectively disable ndt5.
+      - -ndt5_addr=127.0.0.1:3002
+      - -ndt5_ws_addr=127.0.0.1:3001
+
+  jostler:
+    image: measurementlab/jostler:v1.1.0
+    volumes:
+      - ./resultsdir:/resultsdir
+      - ./schemas:/schemas
+      - ./certs:/certs
+    network_mode: "service:ndt-server"
+    depends_on:
+      generate-schemas:
+        condition: service_completed_successfully
+    environment:
+      # TODO: reference service account credentials for upload to GCS.
+      - GOOGLE_APPLICATION_CREDENTIALS=/certs/service-account-autojoin.json
+    command:
+      # TODO: change node name when nodes are registered.
+      - -mlab-node-name=third-party
+      # NOTE: the ndt7 schema must already exist in the target bucket.
+      - -gcs-bucket=staging-mlab-autojoin
+      - -gcs-data-dir=autoload/v2
+      - -local-data-dir=/resultsdir
+      # TODO: update organization name.
+      - -organization=organization1
+      - -experiment=ndt
+      - -datatype=ndt7
+      - -datatype-schema-file=ndt7:/schemas/ndt7.json
+      - -bundle-size-max=20971520
+      - -bundle-age-max=1h
+      - -missed-age=2h
+      - -missed-interval=5m
+      - -extensions=.json
+      - -upload-schema=false
+      - -verbose
+      - -prometheusx.listen-address=:9991
+
+  # Generate the schemas needed by jostler.
+  generate-schemas:
+    image: measurementlab/ndt-server:v0.20.20
+    volumes:
+      - ./schemas:/schemas
+    entrypoint:
+    - /generate-schemas
+    - -ndt7=/schemas/ndt7.json
+
+  # Generate the uuid needed by the ndt-server.
+  generate-uuid:
+    image: measurementlab/uuid:v1.0.0
+    volumes:
+      - ./schemas:/schemas
+    command:
+      - -filename=/schemas/uuid.prefix


### PR DESCRIPTION
This change adds an examples directory with a single example for running ndt with jostler, and uploading bundled measurements to a target GCS bucket.

For this example to function correctly, another process (not included in this PR) must upload an authoritative schema for ndt7 to the target bucket.

See: https://storage.cloud.google.com/staging-mlab-autojoin/autoload/v2/soltesz1/ndt/ndt7/2023/10/20/20231020T180728.641294Z-ndt7-third-party-ndt-data.jsonl.gz

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/1)
<!-- Reviewable:end -->
