### PR TITLE
Add healthchecks for the register service

### DIFF
--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -7,7 +7,7 @@ services:
     # autojoin-register only runs once.
     #
     # TODO(mlab): Change this to a tagged release once the DNS GC is implemented.
-    image: measurementlab/autojoin-register:oneshot
+    image: measurementlab/autojoin-register:latest
     volumes:
       - ./autonode:/autonode
     command:
@@ -17,6 +17,12 @@ services:
       - -organization=${ORGANIZATION}
       - -iata=${IATA}
       - -output=/autonode
+      - -healthcheck-addr=:8001
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001/ready"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
 
   ndt-server:
     image: measurementlab/ndt-server:v0.22.0
@@ -35,7 +41,8 @@ services:
       generate-uuid:
         condition: service_completed_successfully
       register-node:
-        condition: service_completed_successfully
+        condition: service_healthy
+
 
     # NOTE: All containers will use the same network and IP. All ports
     # must be configured on the first service.
@@ -100,6 +107,8 @@ services:
     depends_on:
       ndt-server:
         condition: service_started
+      register-node:
+        condition: service_healthy
     command:
       - -prometheusx.listen-address=:9993
       - -experiment=ndt
@@ -120,6 +129,8 @@ services:
     depends_on:
       ndt-server:
         condition: service_started
+      register-node:
+        condition: service_healthy
     network_mode: "service:ndt-server"
     environment:
       # TODO(mlab): replace service account with output from the registration endpoint.
@@ -149,6 +160,8 @@ services:
         condition: service_completed_successfully
       generate-schemas-annotation2:
         condition: service_completed_successfully
+      register-node:
+        condition: service_healthy
     environment:
       # TODO(mlab): replace service account with output from the registration endpoint.
       - GOOGLE_APPLICATION_CREDENTIALS=/certs/service-account-autojoin.json

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -43,7 +43,6 @@ services:
       register-node:
         condition: service_healthy
 
-
     # NOTE: All containers will use the same network and IP. All ports
     # must be configured on the first service.
     ports:


### PR DESCRIPTION
This builds on top of https://github.com/m-lab/autojoin/pull/28 and updates the register container to the latest (service) version, which keeps refreshing the registration every configured interval rather than doing it just once and then exiting.

All the other services in the file depend on the register container being healthy, which is signaled by the HTTP status code returned by its `/ready` endpoint.

I'm going to replace `latest` with a tagged version after the PR above is merged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/4)
<!-- Reviewable:end -->
