### PR TITLE
Add capabilities and -ports flag

### DIFF
--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -35,7 +35,6 @@ services:
       - ALL
     cap_add:
       - NET_BIND_SERVICE
-      - DAC_OVERRIDE
     depends_on:
       generate-schemas-ndt7:
         condition: service_completed_successfully
@@ -125,6 +124,8 @@ services:
       register-node:
         condition: service_healthy
     network_mode: host
+    cap_add:
+      - NET_BIND_SERVICE
     environment:
       # TODO(mlab): replace service account with output from the registration endpoint.
       - GOOGLE_APPLICATION_CREDENTIALS=/certs/service-account-autojoin.json

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -124,8 +124,6 @@ services:
       register-node:
         condition: service_healthy
     network_mode: host
-    cap_add:
-      - NET_BIND_SERVICE
     environment:
       # TODO(mlab): replace service account with output from the registration endpoint.
       - GOOGLE_APPLICATION_CREDENTIALS=/certs/service-account-autojoin.json

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -14,6 +14,7 @@ services:
       - -iata=${IATA}
       - -output=/autonode
       - -healthcheck-addr=:8001
+      - -ports=9990,9991,9992,9993
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/ready"]
       interval: 3s
@@ -32,6 +33,9 @@ services:
       - ./autocert:/autocert
     cap_drop:
       - ALL
+    cap_add:
+      - NET_BIND_SERVICE
+      - DAC_OVERRIDE
     depends_on:
       generate-schemas-ndt7:
         condition: service_completed_successfully


### PR DESCRIPTION
Adds the `-ports` flag. To be merged only after https://github.com/m-lab/autojoin/pull/32/files and after tagging a new `stable`.

Also, adds the capabilities we need to start ndt-server on privileged ports on the host network.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/6)
<!-- Reviewable:end -->
