### PR TITLE
Get v4 and v6 addresses from ipinfo

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -56,7 +56,7 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} ${VM_NAME} --tunnel-th
 
     # Find the external v4 and v6 addresses for this machine.
     IPV4=\$(curl -s ipinfo.io/ip)
-    IPv6=\$(curl -s -6 v6.ipinfo.io/ip)
+    IPV6=\$(curl -s -6 v6.ipinfo.io/ip)
     
     # Create .env file
     rm .env || true

--- a/deploy.sh
+++ b/deploy.sh
@@ -57,7 +57,7 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} ${VM_NAME} --tunnel-th
     # Find the external v4 and v6 addresses for this machine.
     IPV4=\$(curl -s ipinfo.io/ip)
     IPV6=\$(curl -s -6 v6.ipinfo.io/ip)
-    
+
     # Create .env file
     rm .env || true
     echo "API_KEY=${API_KEY}" >> .env

--- a/deploy.sh
+++ b/deploy.sh
@@ -54,6 +54,10 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} ${VM_NAME} --tunnel-th
     # Stop the docker compose if it's running.
     docker compose -f docker-compose.yml down
 
+    # Find the external v4 and v6 addresses for this machine.
+    IPV4=\$(curl -s ipinfo.io/ip)
+    IPv6=\$(curl -s -6 v6.ipinfo.io/ip)
+    
     # Create .env file
     rm .env || true
     echo "API_KEY=${API_KEY}" >> .env
@@ -64,6 +68,8 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} ${VM_NAME} --tunnel-th
     echo "PROBABILITY=${PROBABILITY}" >> .env
     echo "INTERFACE_NAME=${INTERFACE_NAME}" >> .env
     echo "INTERFACE_MAXRATE=${INTERFACE_MAXRATE}" >> .env
+    echo "IPV4=\$IPV4" >> .env
+    echo "IPV6=\$IPV6" >> .env
 
     # Write service account key to the expected file.
     echo '${SA_KEY}' > certs/service-account-autojoin.json

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -16,6 +16,8 @@ services:
       - -healthcheck-addr=:8001
       - -ports=9990,9991,9992,9993
       - -probability=${PROBABILITY}
+      - -ipv4=${IPV4}
+      - -ipv6=${IPV6}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/ready"]
       interval: 3s


### PR DESCRIPTION
This PR changes the deployment script to explicitly set autojoin-register's -ipv4 and -ipv6 command-line arguments. The addresses are fetched from ipinfo.io. If v6 is unavailable, the corresponding variable (`IPV6`) will just be empty, and not passed to the Autojoin API.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/9)
<!-- Reviewable:end -->
