### PR TITLE
Make docker tag a build variable

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,5 +4,5 @@ steps:
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/build-images/gcloud-jsonnet-cbif:1.1
   dir: '/workspace/'
   args: [
-    '/workspace/deploy.sh $PROJECT_ID mlab ${_API_KEY} ${_PROBABILITY}'
+    '/workspace/deploy.sh $PROJECT_ID ${_DOCKER_TAG} mlab ${_API_KEY} ${_PROBABILITY}'
   ]

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
 set -euxo pipefail
 
-USAGE="$0 <project> <organization> <api-key> <probability>"
+USAGE="$0 <project> <docker-tag> <organization> <api-key> <probability>"
 PROJECT=${1:?Please provide the GCP project (e.g., mlab-sandbox): ${USAGE}}
-ORG=${2:?Please provide the organization (e.g., mlab): ${USAGE}}
-API_KEY=${3:?Please provide the API key: ${USAGE}}
-PROBABILITY=${4:?Please provide the probability: ${USAGE}}
+DOCKER_TAG=${2:?Please provide the Docker tag to deploy: ${USAGE}}
+ORG=${3:?Please provide the organization (e.g., mlab): ${USAGE}}
+API_KEY=${4:?Please provide the API key: ${USAGE}}
+PROBABILITY=${5:?Please provide the probability: ${USAGE}}
 
 IATA="oma"
 VM_ZONE="us-central1-a"
@@ -60,6 +61,7 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} ${VM_NAME} --tunnel-th
 
     # Create .env file
     rm .env || true
+    echo "DOCKER_TAG=${DOCKER_TAG}" >> .env
     echo "API_KEY=${API_KEY}" >> .env
     echo "ORGANIZATION=${ORG}" >> .env
     echo "PROJECT=${PROJECT}" >> .env

--- a/examples/env
+++ b/examples/env
@@ -76,3 +76,4 @@ IPV6=
 
 PROJECT=mlab-autojoin
 LOCATE_URL=locate.measurementlab.net
+DOCKER_TAG=stable

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -1,7 +1,7 @@
 version: '3.7'
 services:
   register-node:
-    image: measurementlab/autojoin-register:stable
+    image: measurementlab/autojoin-register:${DOCKER_TAG}
     pull_policy: always
     network_mode: host
     volumes:


### PR DESCRIPTION
This makes the Docker tag to deploy an env variable that can be set via the build script, so that we can deploy different versions of the autojoin-register container depending on the project:

- sandbox: latest
- staging: main
- autojoin: canary

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/11)
<!-- Reviewable:end -->
