### PR TITLE
Add org and loadbalanced labels

### DIFF
--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -84,6 +84,8 @@ services:
       - -label=type=virtual
       - -label=deployment=byos
       - -label=managed=none
+      - -label=loadbalanced=false
+      - -label=org=${ORGANIZATION}
       # Effectively disable ndt5.
       - -ndt5_addr=127.0.0.1:3002
       - -ndt5_ws_addr=127.0.0.1:3001


### PR DESCRIPTION
This change includes the org and loadbalanced labels for ndt measurements.

These labels are part of standard labels on all ndt measurements (`loadbalanced`) and to simplify filtering data by organization (`org`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/12)
<!-- Reviewable:end -->
