### PR TITLE
Require ndt7 tokens and static verifier key

### DIFF
--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -32,8 +32,7 @@ services:
 
   # ndt-server is the public facing measurement service. Only ndt7 is enabled.
   ndt-server:
-    # TODO(soltesz): update before review v0.22.0+
-    image: measurementlab/ndt-server:sandbox-soltesz-stringfile-flags
+    image: measurementlab/ndt-server:v0.23.0
     network_mode: host
     cap_add:
       - NET_BIND_SERVICE
@@ -146,8 +145,7 @@ services:
         condition: service_healthy
     network_mode: host
     environment:
-      # TODO(mlab): replace service account with output from the registration endpoint.
-      - GOOGLE_APPLICATION_CREDENTIALS=/certs/service-account-autojoin.json
+      - GOOGLE_APPLICATION_CREDENTIALS=/autonode/service-account-autojoin.json
     restart: always
     # NOTE: all database URLs are required.
     command:
@@ -181,8 +179,7 @@ services:
       register-node:
         condition: service_healthy
     environment:
-      # TODO(mlab): replace service account with output from the registration endpoint.
-      - GOOGLE_APPLICATION_CREDENTIALS=/certs/service-account-autojoin.json
+      - GOOGLE_APPLICATION_CREDENTIALS=/autonode/service-account-autojoin.json
     # NOTE: jostler should not restart on exit.
     command:
       - -mlab-node-name-file=/autonode/hostname

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -32,7 +32,8 @@ services:
 
   # ndt-server is the public facing measurement service. Only ndt7 is enabled.
   ndt-server:
-    image: measurementlab/ndt-server:v0.22.0
+    # TODO(soltesz): update before review v0.22.0+
+    image: measurementlab/ndt-server:sandbox-soltesz-stringfile-flags
     network_mode: host
     cap_add:
       - NET_BIND_SERVICE
@@ -99,7 +100,13 @@ services:
       - -ndt5_ws_addr=127.0.0.1:3001
       - -tcpinfo.eventsocket=/schemas/events.sock
       - -autocert.enabled=true
-      - -autocert.hostname=/autonode/hostname
+      - -autocert.hostname=@/autonode/hostname
+      - -token.machine=@/autonode/hostname
+      - -token.verify-key=/locate/verify.pub
+      - -ndt7.token.required=true
+    configs:
+      - source: locate-verify-key
+        target: /locate/verify.pub
 
   # heartbeat reports health and liveness messages to M-Lab's Locate API every
   # 10sec. The Locate API is responsible for directing clients to nearby healthy
@@ -226,3 +233,8 @@ services:
       - ./schemas:/schemas
     command:
       - -filename=/schemas/uuid.prefix
+
+configs:
+  locate-verify-key:
+    content: |
+      {"use":"sig","kty":"OKP","kid":"locate_20200409","crv":"Ed25519","alg":"EdDSA","x":"1tS1d-dd2B-VRBTWzOaq7zUngKDyV409K-o42LN2nx8"}


### PR DESCRIPTION
This change updates the ndt-fullstack.yml docker compose reference configuration to require access tokens.

This change embeds a static verifier key. Since this key is updated infrequently, there is not much risk of breakage until we ultimately provide verifier keys published by the Locate API that are read by the ndt-server at runtime.

This change also updates the service account credentials to those provided by the Autojoin Register API since this is now a supported feature.

Tested using ndt7-client-go targeting the autonode in sandbox:
```
ndt7-client -locate.url 'https://locate-dot-mlab-sandbox.appspot.com/v2/nearest?site=oma396982'
```

And verifying that the resulting test was uploaded to GCS
* https://console.cloud.google.com/storage/browser/_details/archive-mlab-sandbox/autoload/v2/mlab/ndt/ndt7/2024/09/30/20240930T182330.551205Z-ndt7-2248791f-oma396982-ndt-data.jsonl.gz;tab=live_object?project=mlab-sandbox

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/18)
<!-- Reviewable:end -->
