### PR TITLE
Add traceroute-caller to fullstack autonode - scamper2

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -21,6 +21,13 @@ if [ "$PROJECT" = "mlab-autojoin" ]; then
   LOCATE_URL="locate.measurementlab.net"
 fi
 
+if [[ test -f ${DOCKER_COMPOSE_FILE_PATH} ]]; then
+  # NOTE: we will treat the M-Lab deployment as authoritative. New schemas will be
+  # deployed to GCS.  NOTE: backward compatible schema updates will not impact
+  # other organization deployments. However, if there are breaking changes, all
+  # autonode deployments that are pinned to earlier schemas will break.
+  sed -i -e 's/-upload-schema=false/-upload-schema=true/' examples/ndt-fullstack.yml
+fi
 
 # NOTE: We don't use the VM's default credentials because we want to simulate
 # how a non-GCP user would set up an autonode. Instead, we generate a temporary

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,10 +23,11 @@ fi
 
 if test -f ${DOCKER_COMPOSE_FILE_PATH}; then
   # NOTE: we will treat the M-Lab deployment as authoritative. New schemas will be
-  # deployed to GCS.  NOTE: backward compatible schema updates will not impact
-  # other organization deployments. However, if there are breaking changes, all
-  # autonode deployments that are pinned to earlier schemas will break.
-  sed -i -e 's/-upload-schema=false/-upload-schema=true/' examples/ndt-fullstack.yml
+  # deployed to GCS.
+  # NOTE: backward compatible schema updates will not impact other organization
+  # deployments. However, if there are breaking changes, all autonode deployments
+  # that are pinned to earlier schemas will break.
+  sed -i -e 's/-upload-schema=false/-upload-schema=true/' ${DOCKER_COMPOSE_FILE_PATH}
 fi
 
 # NOTE: We don't use the VM's default credentials because we want to simulate

--- a/deploy.sh
+++ b/deploy.sh
@@ -21,7 +21,7 @@ if [ "$PROJECT" = "mlab-autojoin" ]; then
   LOCATE_URL="locate.measurementlab.net"
 fi
 
-if [[ test -f ${DOCKER_COMPOSE_FILE_PATH} ]]; then
+if test -f ${DOCKER_COMPOSE_FILE_PATH}; then
   # NOTE: we will treat the M-Lab deployment as authoritative. New schemas will be
   # deployed to GCS.  NOTE: backward compatible schema updates will not impact
   # other organization deployments. However, if there are breaking changes, all

--- a/examples/env
+++ b/examples/env
@@ -1,5 +1,5 @@
 # This is an example .env file for the ndt-fullstack docker compose file.
-# 
+#
 # ### External directories ###
 #
 # These folders are mounted by the various containers in the fullstack NDT
@@ -8,7 +8,7 @@
 #
 # The only folder that MUST exist and contain the service account key file
 # (see below) is ./certs. This file must also be readable by Docker's user.
-# 
+#
 # All other folders are created and managed by the containers in the Docker
 # compose.
 #
@@ -29,6 +29,9 @@
 #
 # ./autonode: Contains the configuration files for the NDT server and all the
 #   sidecar containers, provided by the Autojoin API on node registration.
+#
+# ./metadata: Contains configuration files used by some services such as
+#   traceroute-caller to read external IP addresses in some environments.
 
 # ### Configuration variables ###
 # Change the following settings according to your environment.

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -215,7 +215,6 @@ services:
     #  - ./certs:/certs
     #  - ./autonode:/autonode
     command:
-      - -uuid-prefix-file=/schemas/uuid.prefix
       - -prometheusx.listen-address=:9994
       - -traceroute-output=/resultsdir/ndt/scamper2
       - -hopannotation-output=/resultsdir/ndt/hopannotation1
@@ -228,6 +227,7 @@ services:
       - -ipservice.sock=/schemas/uuid-annotator.sock
       - -anonymize.ip=none
       - -scamper.trace-type=regular
+      - -output.format=json
 
   # Generate the schemas needed by jostler to assess that the data is backward
   # compatible with upstream schemas and safe to upload.

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -214,6 +214,12 @@ services:
       - ./schemas:/schemas
     #  - ./certs:/certs
     #  - ./autonode:/autonode
+    depends_on:
+      generate-schemas-tracreoute:
+        condition: service_completed_successfully
+      register-node:
+        condition: service_healthy
+    restart: always
     command:
       - -prometheusx.listen-address=:9994
       - -traceroute-output=/resultsdir/ndt/scamper2

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -204,8 +204,8 @@ services:
       - -datatype-schema-file=annotation2:/schemas/annotation2.json
       - -datatype=scamper2
       - -datatype-schema-file=scamper2:/schemas/scamper2.json
-      - -datatype=hopannotation1
-      - -datatype-schema-file=hopannotation1:/schemas/hopannotation1.json
+      - -datatype=hopannotation2
+      - -datatype-schema-file=hopannotation2:/schemas/hopannotation2.json
       - -bundle-size-max=20971520
       - -bundle-age-max=1h
       - -missed-age=2h
@@ -242,7 +242,7 @@ services:
     command:
       - -prometheusx.listen-address=:9994
       - -traceroute-output=/resultsdir/ndt/scamper2
-      - -hopannotation-output=/resultsdir/ndt/hopannotation1
+      - -hopannotation-output=/resultsdir/ndt/hopannotation2
       - -tcpinfo.eventsocket=/schemas/events.sock
       - -IPCacheTimeout=10m
       - -IPCacheUpdatePeriod=1m
@@ -283,7 +283,7 @@ services:
     entrypoint:
     - /generate-schemas
     - -scamper2=/schemas/scamper2.json
-    - -hopannotation1=/schemas/hopannotation1.json
+    - -hopannotation2=/schemas/hopannotation2.json
 
   # Generate the uuid prefix needed by the ndt-server and uuid-annotator.
   generate-uuid:

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -223,6 +223,8 @@ services:
         condition: service_completed_successfully
       register-node:
         condition: service_healthy
+      ndt-server:
+        condition: service_healthy
     restart: always
     command:
       - -prometheusx.listen-address=:9994

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -232,6 +232,7 @@ services:
         condition: service_healthy
       ndt-server:
         condition: service_healthy
+    pull_policy: always
     restart: always
     configs:
       - source: metadata-external-ipv6

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -110,6 +110,11 @@ services:
     configs:
       - source: locate-verify-key
         target: /locate/verify.pub
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      interval: 3s
+      timeout: 5s
+      retries: 10
 
   # heartbeat reports health and liveness messages to M-Lab's Locate API every
   # 10sec. The Locate API is responsible for directing clients to nearby healthy

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -223,8 +223,6 @@ services:
       - ./resultsdir:/resultsdir
       - ./schemas:/schemas
       - ./metadata:/metadata
-    #  - ./certs:/certs
-    #  - ./autonode:/autonode
     depends_on:
       generate-schemas-tracreoute:
         condition: service_completed_successfully

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -216,8 +216,7 @@ services:
       - -prometheusx.listen-address=:9991
 
   traceroute-caller:
-    # TODO(soltesz): update image version.
-    image: measurementlab/traceroute-caller:sandbox-soltesz-autoloadable
+    image: measurementlab/traceroute-caller:v0.12.0
     network_mode: host
     volumes:
       - ./resultsdir:/resultsdir
@@ -274,8 +273,7 @@ services:
 
   generate-schemas-tracreoute:
     network_mode: host
-    # TODO(soltesz): update image version.
-    image: measurementlab/traceroute-caller:sandbox-soltesz-autoloadable
+    image: measurementlab/traceroute-caller:v0.12.0
     volumes:
       - ./schemas:/schemas
     entrypoint:

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -77,6 +77,10 @@ services:
       - target: 9993
         published: 9993
         protocol: tcp
+      # traceroute-caller prometheus.
+      - target: 9994
+        published: 9994
+        protocol: tcp
     command:
       - -uuid-prefix-file=/schemas/uuid.prefix
       - -datadir=/resultsdir/ndt
@@ -202,6 +206,28 @@ services:
       - -verbose
       - -prometheusx.listen-address=:9991
 
+  traceroute-caller:
+    # TODO(soltesz): update image version.
+    image: measurementlab/traceroute-caller:sandbox-soltesz-autoloadable
+    volumes:
+      - ./resultsdir:/resultsdir
+      - ./schemas:/schemas
+    #  - ./certs:/certs
+    #  - ./autonode:/autonode
+    command:
+      - -uuid-prefix-file=/schemas/uuid.prefix
+      - -prometheusx.listen-address=:9994
+      - -traceroute-output=/resultsdir/ndt/scamper2
+      - -hopannotation-output=/resultsdir/ndt/hopannotation1
+      - -tcpinfo.eventsocket=/schemas/events.sock
+      - -IPCacheTimeout=10m
+      - -IPCacheUpdatePeriod=1m
+      - -scamper.timeout=30m
+      - -scamper.tracelb-W=15
+      - -ipservice.sock=/schemas/uuid-annotator.sock
+      - -anonymize.ip=none
+      - -scamper.trace-type=regular
+
   # Generate the schemas needed by jostler to assess that the data is backward
   # compatible with upstream schemas and safe to upload.
   generate-schemas-ndt7:
@@ -221,6 +247,17 @@ services:
     entrypoint:
     - /generate-schemas
     - -ann2=/schemas/annotation2.json
+
+  generate-schemas-tracreoute:
+    network_mode: host
+    # TODO(soltesz): update image version.
+    image: measurementlab/traceroute-caller:sandbox-soltesz-autoloadable
+    volumes:
+      - ./schemas:/schemas
+    entrypoint:
+    - /generate-schemas
+    - -scamper2=/schemas/scamper2.json
+    - -hopannotation1=/schemas/hopannotation1.json
 
   # Generate the uuid prefix needed by the ndt-server and uuid-annotator.
   generate-uuid:

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -197,6 +197,10 @@ services:
       - -datatype-schema-file=ndt7:/schemas/ndt7.json
       - -datatype=annotation2
       - -datatype-schema-file=annotation2:/schemas/annotation2.json
+      - -datatype=scamper2
+      - -datatype-schema-file=scamper2:/schemas/scamper2.json
+      - -datatype=hopannotation1
+      - -datatype-schema-file=hopannotation1:/schemas/hopannotation1.json
       - -bundle-size-max=20971520
       - -bundle-age-max=1h
       - -missed-age=2h

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -218,6 +218,7 @@ services:
   traceroute-caller:
     # TODO(soltesz): update image version.
     image: measurementlab/traceroute-caller:sandbox-soltesz-autoloadable
+    network_mode: host
     volumes:
       - ./resultsdir:/resultsdir
       - ./schemas:/schemas

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -223,7 +223,8 @@ services:
       - -IPCacheTimeout=10m
       - -IPCacheUpdatePeriod=1m
       - -scamper.timeout=30m
-      - -scamper.tracelb-W=15
+      - -scamper.waitprobe=15
+      - -scamper.ptr=true
       - -ipservice.sock=/schemas/uuid-annotator.sock
       - -anonymize.ip=none
       - -scamper.trace-type=regular

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -221,6 +221,7 @@ services:
     volumes:
       - ./resultsdir:/resultsdir
       - ./schemas:/schemas
+      - ./metadata:/metadata
     #  - ./certs:/certs
     #  - ./autonode:/autonode
     depends_on:
@@ -231,6 +232,11 @@ services:
       ndt-server:
         condition: service_healthy
     restart: always
+    configs:
+      - source: metadata-external-ipv6
+        target: /metadata/external-ipv6
+      - source: metadata-external-ip
+        target: /metadata/external-ip
     command:
       - -prometheusx.listen-address=:9994
       - -traceroute-output=/resultsdir/ndt/scamper2
@@ -290,3 +296,9 @@ configs:
   locate-verify-key:
     content: |
       {"use":"sig","kty":"OKP","kid":"locate_20200409","crv":"Ed25519","alg":"EdDSA","x":"1tS1d-dd2B-VRBTWzOaq7zUngKDyV409K-o42LN2nx8"}
+  metadata-external-ip:
+    content: |
+      ${IPV4}
+  metadata-external-ipv6:
+    content: |
+      ${IPV6}

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -111,7 +111,7 @@ services:
       - source: locate-verify-key
         target: /locate/verify.pub
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:80/"]
+      test: ["CMD", "wget", "http://localhost:80/"]
       interval: 3s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
This change adds the latest traceroute-caller to the ndt fullstack autonode configuration to begin collecting scamper2 traceroutes from test servers.

Additionally, `deploy.sh` changes the flag to jostler to upload schemas. *This makes the M-Lab autonode deployment the authoritative source for schema updates that affect all autonode deployments.*

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/20)
<!-- Reviewable:end -->
