### PR TITLE
Move autonode to us-central1-c

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -9,7 +9,7 @@ API_KEY=${4:?Please provide the API key: ${USAGE}}
 PROBABILITY=${5:?Please provide the probability: ${USAGE}}
 
 IATA="oma"
-VM_ZONE="us-central1-a"
+VM_ZONE="us-central1-c"
 VM_NAME="autonode"
 DOCKER_COMPOSE_FILE_PATH="examples/ndt-fullstack.yml"
 INTERFACE_NAME="ens4"


### PR DESCRIPTION
Continuation of changes to enable end to end monitoring of the autonodes in sandbox and staging (https://github.com/m-lab/terraform-support/pull/106, https://github.com/m-lab/prometheus-support/pull/1064), this change move the autonode to us-central1-c which is the same as prometheus in all projects.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/21)
<!-- Reviewable:end -->
