### PR TITLE
Fix: Prevent health check failures

### DIFF
--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -111,7 +111,7 @@ services:
       - source: locate-verify-key
         target: /locate/verify.pub
     healthcheck:
-      test: ["CMD", "wget", "http://localhost:80/"]
+      test: ["CMD", "wget", "-O/dev/null", "-q", "http://localhost:80/"]
       interval: 3s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
This change modifies the health check to the ndt-server using wget.

Previously, the wget command would work the first time, and save the index.html locally. The second time wget runs it would fail due to the index.html file already existing, causing the ndt-server to report as "unhealthy", even when it was fine.
This change prevents any file from being written and reports ndt-server health correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/23)
<!-- Reviewable:end -->
