### PR TITLE
Install to non-root user and remove SA key 

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -33,9 +33,16 @@ fi
 # Copy the docker compose file to the VM.
 gcloud --project ${PROJECT} compute scp --zone ${VM_ZONE} ${DOCKER_COMPOSE_FILE_PATH} ${VM_NAME}:~/docker-compose.yml --tunnel-through-iap
 
-# Setup script. This stops docker compose, creates the required folders, writes
-# the SA key, re-creates the .env file and restarts docker compose.
-gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} ${VM_NAME} --tunnel-through-iap <<EOF
+# TODO(soltesz): remove root@ logic after deployment.
+# Shutdown the version running as root.
+gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} root@${VM_NAME} --tunnel-through-iap <<EOF
+    # Stop the docker compose if it's running.
+    docker compose -f docker-compose.yml down
+EOF
+
+# Setup script. This stops docker compose, creates the required folders,
+# creates the .env file and restarts docker compose.
+gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --tunnel-through-iap <<EOF
     set -euxo pipefail
     # Create volume folders if not present.
     mkdir -p autocert autonode certs html schemas resultsdir

--- a/deploy.sh
+++ b/deploy.sh
@@ -45,8 +45,8 @@ EOF
 gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --tunnel-through-iap <<EOF
     set -euxo pipefail
     whoami
-    # Create volume folders if not present.
-    # mkdir -p autocert autonode certs html schemas resultsdir metadata
+    # Enable BBR.
+    sudo modprobe tcp_bbr
 
     # Stop the docker compose if it's running.
     docker compose -f docker-compose.yml down

--- a/deploy.sh
+++ b/deploy.sh
@@ -35,14 +35,14 @@ gcloud --project ${PROJECT} compute scp --zone ${VM_ZONE} ${DOCKER_COMPOSE_FILE_
 
 # TODO(soltesz): remove root@ logic after deployment.
 # Shutdown the version running as root.
-gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} root@${VM_NAME} --tunnel-through-iap <<EOF
+gcloud --project ${PROJECT} compute ssh --quiet --zone ${VM_ZONE} root@${VM_NAME} --tunnel-through-iap <<EOF
     # Stop the docker compose if it's running.
     docker compose -f docker-compose.yml down
 EOF
 
 # Setup script. This stops docker compose, creates the required folders,
 # creates the .env file and restarts docker compose.
-gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --tunnel-through-iap <<EOF
+gcloud --project ${PROJECT} compute ssh --quiet --zone ${VM_ZONE} autonode@${VM_NAME} --tunnel-through-iap <<EOF
     set -euxo pipefail
     # Create volume folders if not present.
     mkdir -p autocert autonode certs html schemas resultsdir

--- a/deploy.sh
+++ b/deploy.sh
@@ -46,7 +46,7 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --
     set -euxo pipefail
     whoami
     # Create volume folders if not present.
-    mkdir -p autocert autonode certs html schemas resultsdir metadata
+    # mkdir -p autocert autonode certs html schemas resultsdir metadata
 
     # Stop the docker compose if it's running.
     docker compose -f docker-compose.yml down

--- a/deploy.sh
+++ b/deploy.sh
@@ -30,26 +30,6 @@ if test -f ${DOCKER_COMPOSE_FILE_PATH}; then
   sed -i -e 's/-upload-schema=false/-upload-schema=true/' ${DOCKER_COMPOSE_FILE_PATH}
 fi
 
-# NOTE: We don't use the VM's default credentials because we want to simulate
-# how a non-GCP user would set up an autonode. Instead, we generate a temporary
-# key for the autonode service account that will only exist until the next
-# deployment.
-
-# Delete any existing keys for the autonode SA. Ignore failures due to
-# system-managed keys that cannot be deleted.
-for key in $(gcloud iam service-accounts keys list \
-    --iam-account=${SA_ACCOUNT} \
-    --created-before=$(date --iso-8601=seconds -d "10 mins ago") | \
-    cut -f1 -d " " | tail -n +2)
-do
-    gcloud iam service-accounts keys delete --iam-account=${SA_ACCOUNT} ${key} -q || true
-done
-
-# Create a new key.
-gcloud iam service-accounts keys create key.json \
-    --iam-account=${SA_ACCOUNT}
-SA_KEY=$(<key.json)
-
 # Copy the docker compose file to the VM.
 gcloud --project ${PROJECT} compute scp --zone ${VM_ZONE} ${DOCKER_COMPOSE_FILE_PATH} ${VM_NAME}:~/docker-compose.yml --tunnel-through-iap
 
@@ -80,9 +60,6 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} ${VM_NAME} --tunnel-th
     echo "INTERFACE_MAXRATE=${INTERFACE_MAXRATE}" >> .env
     echo "IPV4=\$IPV4" >> .env
     echo "IPV6=\$IPV6" >> .env
-
-    # Write service account key to the expected file.
-    echo '${SA_KEY}' > certs/service-account-autojoin.json
 
     # Start the docker compose again.
     docker compose -f docker-compose.yml up -d

--- a/deploy.sh
+++ b/deploy.sh
@@ -31,19 +31,22 @@ if test -f ${DOCKER_COMPOSE_FILE_PATH}; then
 fi
 
 # Copy the docker compose file to the VM.
-gcloud --project ${PROJECT} compute scp --zone ${VM_ZONE} ${DOCKER_COMPOSE_FILE_PATH} ${VM_NAME}:~/docker-compose.yml --tunnel-through-iap
+gcloud --project ${PROJECT} compute scp --zone ${VM_ZONE} ${DOCKER_COMPOSE_FILE_PATH} autonode@${VM_NAME}:~/docker-compose.yml --tunnel-through-iap
 
 # TODO(soltesz): remove root@ logic after deployment.
 # Shutdown the version running as root.
-gcloud --project ${PROJECT} compute ssh --quiet --zone ${VM_ZONE} root@${VM_NAME} --tunnel-through-iap <<EOF
+gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} root@${VM_NAME} --tunnel-through-iap <<EOF
+    set -x
+    whoami
     # Stop the docker compose if it's running.
     docker compose -f docker-compose.yml down
 EOF
 
 # Setup script. This stops docker compose, creates the required folders,
 # creates the .env file and restarts docker compose.
-gcloud --project ${PROJECT} compute ssh --quiet --zone ${VM_ZONE} autonode@${VM_NAME} --tunnel-through-iap <<EOF
+gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --tunnel-through-iap <<EOF
     set -euxo pipefail
+    whoami
     # Create volume folders if not present.
     mkdir -p autocert autonode certs html schemas resultsdir
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -36,8 +36,6 @@ gcloud --project ${PROJECT} compute scp --zone ${VM_ZONE} ${DOCKER_COMPOSE_FILE_
 # TODO(soltesz): remove root@ logic after deployment.
 # Shutdown the version running as root.
 gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} root@${VM_NAME} --tunnel-through-iap <<EOF
-    set -x
-    whoami
     # Stop the docker compose if it's running.
     docker compose -f docker-compose.yml down
 EOF
@@ -48,7 +46,7 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --
     set -euxo pipefail
     whoami
     # Create volume folders if not present.
-    mkdir -p autocert autonode certs html schemas resultsdir
+    mkdir -p autocert autonode certs html schemas resultsdir metadata
 
     # Stop the docker compose if it's running.
     docker compose -f docker-compose.yml down

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,9 +26,15 @@ The `ndt-fullstack.yml` and `env` file are a complete configuration for an
 autonode deployment. Please review the `env` file comments for hints about
 correct configuration.
 
-Additionally, ensure that the bbr module is loaded.
+Requirements:
+
+* version v2.23.3 or later of docker compose
+* the bbr module is loaded in the kernel
 
 ```sh
+docker compose version
+
 sudo modprobe tcp_bbr
-docker-compose --env-file env --file ndt-fullstack.yml up -d
+
+docker compose --env-file env --file ndt-fullstack.yml up -d
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,6 +26,9 @@ The `ndt-fullstack.yml` and `env` file are a complete configuration for an
 autonode deployment. Please review the `env` file comments for hints about
 correct configuration.
 
+Additionally, ensure that the bbr module is loaded.
+
 ```sh
-docker-compose --env-file env --file ndt-fullstack.yml up
+sudo modprobe tcp_bbr
+docker-compose --env-file env --file ndt-fullstack.yml up -d
 ```

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -1,4 +1,3 @@
-version: '3.7'
 services:
   # Register this node with the Autojoin API. A successful registration will
   # assign a DNS name for this node based on the public IPs, their ASN,


### PR DESCRIPTION
This change modifies the autonode deployment to use a non-priviliged user account to match common deployment environments.

This change also removes the deployment of the service account key, since this functionality is now provided by the Autojoin.Register API.

This change also removes the docker compose file `version` since this is [ignored by docker compose](https://docs.docker.com/reference/compose-file/version-and-name/).

As well, this change enables the `tcp_bbr` module before starting the docker containers and documents this configuration in the `examples/README.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/24)
<!-- Reviewable:end -->
