### PR TITLE
Add check-config and ndt profiles to ndt-fullstack.yml config

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -33,13 +33,6 @@ fi
 # Copy the docker compose file to the VM.
 gcloud --project ${PROJECT} compute scp --zone ${VM_ZONE} ${DOCKER_COMPOSE_FILE_PATH} autonode@${VM_NAME}:~/docker-compose.yml --tunnel-through-iap
 
-# TODO(soltesz): remove root@ logic after deployment.
-# Shutdown the version running as root.
-gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} root@${VM_NAME} --tunnel-through-iap <<EOF
-    # Stop the docker compose if it's running.
-    docker compose -f docker-compose.yml down
-EOF
-
 # Setup script. This stops docker compose, creates the required folders,
 # creates the .env file and restarts docker compose.
 gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --tunnel-through-iap <<EOF
@@ -49,7 +42,7 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --
     sudo modprobe tcp_bbr
 
     # Stop the docker compose if it's running.
-    docker compose -f docker-compose.yml down
+    docker compose --profile ndt -f docker-compose.yml down
 
     # Find the external v4 and v6 addresses for this machine.
     IPV4=\$(curl -s ipinfo.io/ip)
@@ -70,6 +63,7 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --
     echo "IPV6=\$IPV6" >> .env
 
     # Start the docker compose again.
-    docker compose -f docker-compose.yml up -d
+    docker compose --profile ndt -f docker-compose.yml up -d
+
 EOF
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,13 +28,18 @@ correct configuration.
 
 Requirements:
 
-* version v2.23.3 or later of docker compose
-* the bbr module is loaded in the kernel
+* version v2.28 or later of docker compose
+* the bbr module must be loaded in the kernel
 
 ```sh
 docker compose version
 
 sudo modprobe tcp_bbr
+# Recommended: add "tcp_bbr" to /etc/modules
 
-docker compose --env-file env --file ndt-fullstack.yml up -d
+# Verify environment and credentials are working, then manually shutdown with ctrl-C.
+docker compose --profile check-config --env-file env --file ndt-fullstack.yml up
+
+# Start ndt service in background. This will restart automatically on reboot.
+docker compose --profile ndt --env-file env --file ndt-fullstack.yml up -d
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,8 +28,8 @@ correct configuration.
 
 Requirements:
 
-* version v2.28 or later of docker compose
-* the bbr module must be loaded in the kernel
+* Version v2.28 or later of docker compose, installed from [official docker images](https://docs.docker.com/engine/install/)
+* The `tcp_bbr` module must be loaded in the kernel
 
 ```sh
 docker compose version

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -7,6 +7,7 @@ services:
   register-node:
     # NOTE: register should not be restarted on failure.
     image: measurementlab/autojoin-register:${DOCKER_TAG}
+    profiles: [check-config,ndt]
     pull_policy: always
     network_mode: host
     volumes:
@@ -33,6 +34,7 @@ services:
   # ndt-server is the public facing measurement service. Only ndt7 is enabled.
   ndt-server:
     image: measurementlab/ndt-server:v0.23.0
+    profiles: [ndt]
     network_mode: host
     cap_add:
       - NET_BIND_SERVICE
@@ -121,6 +123,7 @@ services:
   # servers.
   heartbeat:
     image: measurementlab/heartbeat:v0.15.1
+    profiles: [ndt]
     volumes:
       - ./autonode:/autonode
     depends_on:
@@ -142,6 +145,7 @@ services:
   # client and server IP so each NDT measurement is annotated in BigQuery.
   uuid-annotator:
     image: measurementlab/uuid-annotator:v0.5.10
+    profiles: [ndt]
     volumes:
       - ./resultsdir:/resultsdir
       - ./schemas:/schemas
@@ -174,6 +178,7 @@ services:
   # compatible with upstream schemas.
   jostler:
     image: measurementlab/jostler:v1.1.4
+    profiles: [check-config,ndt]
     volumes:
       - ./resultsdir:/resultsdir
       - ./schemas:/schemas
@@ -218,6 +223,7 @@ services:
 
   traceroute-caller:
     image: measurementlab/traceroute-caller:v0.12.0
+    profiles: [ndt]
     network_mode: host
     volumes:
       - ./resultsdir:/resultsdir

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -11,6 +11,7 @@ services:
     network_mode: host
     volumes:
       - ./autonode:/autonode
+    restart: always
     command:
       - -endpoint=https://autojoin-dot-${PROJECT}.appspot.com/autojoin/v0/node/register
       - -key=${API_KEY}
@@ -186,6 +187,7 @@ services:
         condition: service_completed_successfully
       register-node:
         condition: service_healthy
+    restart: always
     environment:
       - GOOGLE_APPLICATION_CREDENTIALS=/autonode/service-account-autojoin.json
     # NOTE: jostler should not restart on exit.


### PR DESCRIPTION
This change adds [service profiles](https://docs.docker.com/compose/how-tos/profiles/) for `check-config` and `ndt` to the `ndt-fullstack.yml` configuration.

The most common setup issue is correctly registering the node with the Autojoin API and jostler authenticating with the service account credentials. This change creates an explicit `check-config` step to give hosts an opportunity to check whether these configurations are working before starting the ndt service itself.

These changes now require specifying a service profile to start the `ndt` service as well. This change includes notes in the examples/README.md.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/26)
<!-- Reviewable:end -->
