### PR TITLE
Define new TYPE and UPLINK vars for registration 

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,5 +4,5 @@ steps:
 - name: us-central1-docker.pkg.dev/$PROJECT_ID/build-images/gcloud-jsonnet-cbif:1.1
   dir: '/workspace/'
   args: [
-    '/workspace/deploy.sh $PROJECT_ID ${_DOCKER_TAG} mlab ${_API_KEY} ${_PROBABILITY}'
+    '/workspace/deploy.sh $PROJECT_ID mlab ${_API_KEY} ${_PROBABILITY}'
   ]

--- a/deploy.sh
+++ b/deploy.sh
@@ -3,10 +3,9 @@ set -euxo pipefail
 
 USAGE="$0 <project> <docker-tag> <organization> <api-key> <probability>"
 PROJECT=${1:?Please provide the GCP project (e.g., mlab-sandbox): ${USAGE}}
-DOCKER_TAG=${2:?Please provide the Docker tag to deploy: ${USAGE}}
-ORG=${3:?Please provide the organization (e.g., mlab): ${USAGE}}
-API_KEY=${4:?Please provide the API key: ${USAGE}}
-PROBABILITY=${5:?Please provide the probability: ${USAGE}}
+ORG=${2:?Please provide the organization (e.g., mlab): ${USAGE}}
+API_KEY=${3:?Please provide the API key: ${USAGE}}
+PROBABILITY=${4:?Please provide the probability: ${USAGE}}
 
 IATA="oma"
 VM_ZONE="us-central1-c"
@@ -20,6 +19,10 @@ LOCATE_URL="locate-dot-${PROJECT}.appspot.com"
 if [ "$PROJECT" = "mlab-autojoin" ]; then
   LOCATE_URL="locate.measurementlab.net"
 fi
+
+DOCKER_TAG=$(
+  curl --silent  https://api.github.com/repos/m-lab/autojoin/releases/latest | jq -r '.tag_name'
+)
 
 if test -f ${DOCKER_COMPOSE_FILE_PATH}; then
   # NOTE: we will treat the M-Lab deployment as authoritative. New schemas will be

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-USAGE="$0 <project> <docker-tag> <organization> <api-key> <probability>"
+USAGE="$0 <project> <organization> <api-key> <probability>"
 PROJECT=${1:?Please provide the GCP project (e.g., mlab-sandbox): ${USAGE}}
 ORG=${2:?Please provide the organization (e.g., mlab): ${USAGE}}
 API_KEY=${3:?Please provide the API key: ${USAGE}}
@@ -65,7 +65,7 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --
     echo "IPV4=\$IPV4" >> .env
     echo "IPV6=\$IPV6" >> .env
     echo "TYPE=virtual" >> .env
-    echo "UPLINK=1g" >> .env
+    echo "UPLINK=7g" >> .env
 
     # Start the docker compose again.
     docker compose --profile ndt -f docker-compose.yml up -d

--- a/deploy.sh
+++ b/deploy.sh
@@ -61,9 +61,10 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --
     echo "INTERFACE_MAXRATE=${INTERFACE_MAXRATE}" >> .env
     echo "IPV4=\$IPV4" >> .env
     echo "IPV6=\$IPV6" >> .env
+    echo "TYPE=virtual" >> .env
+    echo "UPLINK=1g" >> .env
 
     # Start the docker compose again.
     docker compose --profile ndt -f docker-compose.yml up -d
 
 EOF
-

--- a/examples/env
+++ b/examples/env
@@ -57,8 +57,15 @@ PROBABILITY=0.1
 # INTERFACE_NAME is the name of the interface to apply INTERFACE_MAXRATE to.
 INTERFACE_NAME=
 
+# UPLINK is the speed of the uplink the M-Lab machine is connected to. The value
+# must be expressed as an integer followed by the letter "g" (e.g., "1g", "10g",
+# "25g"), where "g" represents Gbps (gigabits per second). The minimum uplink
+# M-lab requires is 1g, but 10g or greater is recommended.
+UPLINK=
+
 # INTERFACE_MAXRATE is the rate (in bit/s) after which the NDT server will
-# refuse new connections. Set it according to this node's uplink.
+# refuse new connections. Set it according to this node's uplink defined in
+# UPLINK.
 # Recommended values:
 # - 1G: INTERFACE_MAXRATE=150000000
 # - 10G: INTERFACE_MAXRATE=7000000000
@@ -73,6 +80,11 @@ IPV4=
 # If you want you node to be accessible over IPv6, this must be set.
 IPV6=
 
+# TYPE is the type of machine that will be running the M-Lab software. The only
+# valid values are "physical" or "virtual". This helps M-Lab understand the
+# environment where the software is running. In other words, is the machine a
+# bare-metal machine dedicated to M-Lab, or a VM?
+TYPE=
 
 # ### Static configuration variables ###
 # ###    Do NOT change these.        ###

--- a/examples/env
+++ b/examples/env
@@ -91,4 +91,4 @@ TYPE=
 
 PROJECT=mlab-autojoin
 LOCATE_URL=locate.measurementlab.net
-DOCKER_TAG=latest
+DOCKER_TAG=stable

--- a/examples/env
+++ b/examples/env
@@ -86,9 +86,17 @@ IPV6=
 # bare-metal machine dedicated to M-Lab, or a VM?
 TYPE=
 
+# DOCKER_TAG refers to the latest release of the repository
+# github.com/m-lab/autojoin. Visit the releases page of that repository:
+#
+# https://github.com/m-lab/autojoin/releases
+#
+# Use the git tag of the latest release as the value for this variable e.g.,
+# "v0.2.11"
+DOCKER_TAG=
+
 # ### Static configuration variables ###
 # ###    Do NOT change these.        ###
 
 PROJECT=mlab-autojoin
 LOCATE_URL=locate.measurementlab.net
-DOCKER_TAG=stable

--- a/examples/env
+++ b/examples/env
@@ -91,4 +91,4 @@ TYPE=
 
 PROJECT=mlab-autojoin
 LOCATE_URL=locate.measurementlab.net
-DOCKER_TAG=stable
+DOCKER_TAG=latest

--- a/examples/env
+++ b/examples/env
@@ -86,15 +86,6 @@ IPV6=
 # bare-metal machine dedicated to M-Lab, or a VM?
 TYPE=
 
-# DOCKER_TAG refers to the latest release of the repository
-# github.com/m-lab/autojoin. Visit the releases page of that repository:
-#
-# https://github.com/m-lab/autojoin/releases
-#
-# Use the git tag of the latest release as the value for this variable e.g.,
-# "v0.2.11"
-DOCKER_TAG=
-
 # ### Static configuration variables ###
 # ###    Do NOT change these.        ###
 

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -25,6 +25,8 @@ services:
       - -probability=${PROBABILITY}
       - -ipv4=${IPV4}
       - -ipv6=${IPV6}
+      - -type=${TYPE}
+      - -uplink=${UPLINK}
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8001/ready"]
       interval: 3s

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -6,7 +6,7 @@ services:
   # the Autojoin API every hour.
   register-node:
     # NOTE: register should not be restarted on failure.
-    image: measurementlab/autojoin-register:${DOCKER_TAG}
+    image: measurementlab/autojoin-register:v0.2.11
     profiles: [check-config,ndt]
     pull_policy: always
     network_mode: host


### PR DESCRIPTION
This change allows Autojoin clients to specify the machine type and the uplink speed. This information will be passed to Locate via Heartbeat messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/27)
<!-- Reviewable:end -->
