### PR TITLE
Add external-ip(v6) label to ndt-server result files

### DIFF
--- a/examples/env
+++ b/examples/env
@@ -72,8 +72,7 @@ UPLINK=
 INTERFACE_MAXRATE=
 
 # IPV4 is the external IPv4 address that this node will be reachable at.
-# If left empty, the v4 address used to connect to Autojoin API by the register
-# container is used instead.
+# This is required.
 IPV4=
 
 # IPV6 is the external IPv6 address that this node will be reachable at.

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -314,8 +314,8 @@ configs:
     content: |
       {"use":"sig","kty":"OKP","kid":"locate_20200409","crv":"Ed25519","alg":"EdDSA","x":"1tS1d-dd2B-VRBTWzOaq7zUngKDyV409K-o42LN2nx8"}
   metadata-external-ip:
-    content: |
+    content: |-
       ${IPV4}
   metadata-external-ipv6:
-    content: |
+    content: |-
       ${IPV6}

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -13,6 +13,11 @@ services:
     volumes:
       - ./autonode:/autonode
     restart: always
+    configs:
+      - source: metadata-external-ipv6
+        target: /metadata/external-ipv6
+      - source: metadata-external-ip
+        target: /metadata/external-ip
     command:
       - -endpoint=https://autojoin-dot-${PROJECT}.appspot.com/autojoin/v0/node/register
       - -key=${API_KEY}
@@ -23,8 +28,8 @@ services:
       - -healthcheck-addr=:8001
       - -ports=9990,9991,9992,9993,9994
       - -probability=${PROBABILITY}
-      - -ipv4=${IPV4}
-      - -ipv6=${IPV6}
+      - -ipv4=@/metadata/external-ip
+      - -ipv6=@/metadata/external-ipv6
       - -type=${TYPE}
       - -uplink=${UPLINK}
     healthcheck:
@@ -99,11 +104,13 @@ services:
       - -txcontroller.max-rate=${INTERFACE_MAXRATE}
       - -prometheusx.listen-address=:9990
       # Add server metadata.
-      - -label=type=virtual
+      - -label=type=${TYPE}
       - -label=deployment=byos
       - -label=managed=none
       - -label=loadbalanced=false
       - -label=org=${ORGANIZATION}
+      - -label=external-ip=@/metadata/external-ip
+      - -label=external-ipv6=@/metadata/external-ipv6
       # Effectively disable ndt5.
       - -ndt5_addr=127.0.0.1:3002
       - -ndt5_ws_addr=127.0.0.1:3001
@@ -116,6 +123,10 @@ services:
     configs:
       - source: locate-verify-key
         target: /locate/verify.pub
+      - source: metadata-external-ipv6
+        target: /metadata/external-ipv6
+      - source: metadata-external-ip
+        target: /metadata/external-ip
     healthcheck:
       test: ["CMD", "wget", "-O/dev/null", "-q", "http://localhost:80/"]
       interval: 3s

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -13,11 +13,6 @@ services:
     volumes:
       - ./autonode:/autonode
     restart: always
-    configs:
-      - source: metadata-external-ipv6
-        target: /metadata/external-ipv6
-      - source: metadata-external-ip
-        target: /metadata/external-ip
     command:
       - -endpoint=https://autojoin-dot-${PROJECT}.appspot.com/autojoin/v0/node/register
       - -key=${API_KEY}
@@ -28,8 +23,8 @@ services:
       - -healthcheck-addr=:8001
       - -ports=9990,9991,9992,9993,9994
       - -probability=${PROBABILITY}
-      - -ipv4=@/metadata/external-ip
-      - -ipv6=@/metadata/external-ipv6
+      - -ipv4=${IPV4}
+      - -ipv6=${IPV6}
       - -type=${TYPE}
       - -uplink=${UPLINK}
     healthcheck:
@@ -109,8 +104,8 @@ services:
       - -label=managed=none
       - -label=loadbalanced=false
       - -label=org=${ORGANIZATION}
-      - -label=external-ip=@/metadata/external-ip
-      - -label=external-ipv6=@/metadata/external-ipv6
+      - -label=external-ip=${IPV4}
+      - -label=external-ipv6=${IPV6}
       # Effectively disable ndt5.
       - -ndt5_addr=127.0.0.1:3002
       - -ndt5_ws_addr=127.0.0.1:3001
@@ -123,10 +118,6 @@ services:
     configs:
       - source: locate-verify-key
         target: /locate/verify.pub
-      - source: metadata-external-ipv6
-        target: /metadata/external-ipv6
-      - source: metadata-external-ip
-        target: /metadata/external-ip
     healthcheck:
       test: ["CMD", "wget", "-O/dev/null", "-q", "http://localhost:80/"]
       interval: 3s


### PR DESCRIPTION
This PR adds the `external-ip` and `external-ipv6` labels to test results and fixes an inconsistency in the `type` label.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/29)
<!-- Reviewable:end -->
