### PR TITLE
Adds 9100 to list of ports sent to Autojoin API

### DIFF
--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -21,7 +21,7 @@ services:
       - -iata=${IATA}
       - -output=/autonode
       - -healthcheck-addr=:8001
-      - -ports=9990,9991,9992,9993,9994
+      - -ports=9100,9990,9991,9992,9993,9994
       - -probability=${PROBABILITY}
       - -ipv4=${IPV4}
       - -ipv6=${IPV6}
@@ -273,6 +273,7 @@ services:
     volumes:
       - /:/host:ro,rslave
     command:
+      - --web.listen-address=:9100
       - --path.rootfs=/host
       - --collector.disable-defaults
       - --collector.cpu


### PR DESCRIPTION
Adding this port to the list of ports will cause Autojoin to return Prometheus targets for node_exporter, which should cause the Prometheus instance in the mlab-autojoin project to automatically start scraping node_exporter.

Also, even though 9100 is the default node_exporter port, explicitly set it in the container specification so that it is more transparent in the compose file whey we are sending port 9100 to Autojoin.