### PR TITLE
Changes node_exporter port from 9100 to 9995

### DIFF
--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -21,7 +21,7 @@ services:
       - -iata=${IATA}
       - -output=/autonode
       - -healthcheck-addr=:8001
-      - -ports=9100,9990,9991,9992,9993,9994
+      - -ports=9990,9991,9992,9993,9994,9995
       - -probability=${PROBABILITY}
       - -ipv4=${IPV4}
       - -ipv6=${IPV6}
@@ -273,7 +273,7 @@ services:
     volumes:
       - /:/host:ro,rslave
     command:
-      - --web.listen-address=:9100
+      - --web.listen-address=:9995
       - --path.rootfs=/host
       - --collector.disable-defaults
       - --collector.cpu


### PR DESCRIPTION
This makes the port number contiguous with the other monitoring ports.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/33)
<!-- Reviewable:end -->
