### PR TITLE
Runs a "check-config" container to upload datatype schemas to GCS

### DIFF
--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -280,7 +280,7 @@ services:
       - ./schemas:/schemas
       - ./metadata:/metadata
     depends_on:
-      generate-schemas-tracreoute:
+      generate-schemas-traceroute:
         condition: service_completed_successfully
       register-node:
         condition: service_healthy
@@ -350,7 +350,7 @@ services:
       - /generate-schemas
       - -ann2=/schemas/annotation2.json
 
-  generate-schemas-tracreoute:
+  generate-schemas-traceroute:
     network_mode: host
     image: measurementlab/traceroute-caller:v0.12.0
     volumes:

--- a/examples/ndt-fullstack.yml
+++ b/examples/ndt-fullstack.yml
@@ -183,7 +183,7 @@ services:
   # compatible with upstream schemas.
   jostler:
     image: measurementlab/jostler:v1.1.4
-    profiles: [check-config, ndt]
+    profiles: [ndt]
     volumes:
       - ./resultsdir:/resultsdir
       - ./schemas:/schemas
@@ -191,10 +191,6 @@ services:
       - ./autonode:/autonode
     network_mode: host
     depends_on:
-      generate-schemas-ndt7:
-        condition: service_completed_successfully
-      generate-schemas-annotation2:
-        condition: service_completed_successfully
       register-node:
         condition: service_healthy
     restart: always
@@ -223,6 +219,55 @@ services:
       - -missed-interval=5m
       - -extensions=.json
       - -upload-schema=false
+      - -verbose
+      - -prometheusx.listen-address=:9991
+
+  # This container only gets run with the "check-config" profile, and is only
+  # responsible for generating and uploading the schemas to GCS.
+  jostler-upload-schemas:
+    image: measurementlab/jostler:v1.1.4
+    profiles: [check-config]
+    volumes:
+      - ./resultsdir:/resultsdir
+      - ./schemas:/schemas
+      - ./certs:/certs
+      - ./autonode:/autonode
+    network_mode: host
+    depends_on:
+      generate-schemas-ndt7:
+        condition: service_completed_successfully
+      generate-schemas-annotation2:
+        condition: service_completed_successfully
+      generate-schemas-traceroute:
+        condition: service_completed_successfully
+      register-node:
+        condition: service_healthy
+    restart: always
+    environment:
+      - GOOGLE_APPLICATION_CREDENTIALS=/autonode/service-account-autojoin.json
+    # NOTE: jostler should not restart on exit.
+    command:
+      - -mlab-node-name=@/autonode/hostname
+      # NOTE: the ndt7 schema must already exist in the target bucket.
+      - -gcs-bucket=archive-${PROJECT}
+      - -gcs-data-dir=autoload/v2
+      - -local-data-dir=/resultsdir
+      - -organization=${ORGANIZATION}
+      - -experiment=ndt
+      - -datatype=ndt7
+      - -datatype-schema-file=ndt7:/schemas/ndt7.json
+      - -datatype=annotation2
+      - -datatype-schema-file=annotation2:/schemas/annotation2.json
+      - -datatype=scamper2
+      - -datatype-schema-file=scamper2:/schemas/scamper2.json
+      - -datatype=hopannotation2
+      - -datatype-schema-file=hopannotation2:/schemas/hopannotation2.json
+      - -bundle-size-max=20971520
+      - -bundle-age-max=1h
+      - -missed-age=2h
+      - -missed-interval=5m
+      - -extensions=.json
+      - -upload-schema=true
       - -verbose
       - -prometheusx.listen-address=:9991
 
@@ -265,6 +310,7 @@ services:
 
   node-exporter:
     image: quay.io/prometheus/node-exporter:v1.9.0
+    profiles: [ndt]
     container_name: node-exporter
     restart: always
     network_mode: host


### PR DESCRIPTION
Also, makes the new "jostler-upload-schemas" container depend on the generate-schema-traceroute service, which it lacked before.

Also, only run node_exporter for the "ndt" profile.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/39)
<!-- Reviewable:end -->
