### PR TITLE
feat(heartbeat): add separate AUTH_URL variable for token exchange

### DIFF
--- a/.build/deploy.sh
+++ b/.build/deploy.sh
@@ -16,8 +16,10 @@ INTERFACE_MAXRATE="150000000"
 SA_ACCOUNT="autonode@${PROJECT}.iam.gserviceaccount.com"
 
 LOCATE_URL="locate-dot-${PROJECT}.appspot.com"
+AUTH_URL="auth.${PROJECT}.measurementlab.net"
 if [ "$PROJECT" = "mlab-autojoin" ]; then
   LOCATE_URL="locate.measurementlab.net"
+  AUTH_URL="auth.mlab-oti.measurementlab.net"
 fi
 
 DOCKER_TAG=$(
@@ -59,6 +61,7 @@ gcloud --project ${PROJECT} compute ssh --zone ${VM_ZONE} autonode@${VM_NAME} --
     echo "PROJECT=${PROJECT}" >> .env
     echo "IATA=${IATA}" >> .env
     echo "LOCATE_URL=${LOCATE_URL}" >> .env
+    echo "AUTH_URL=${AUTH_URL}" >> .env
     echo "PROBABILITY=${PROBABILITY}" >> .env
     echo "INTERFACE_NAME=${INTERFACE_NAME}" >> .env
     echo "INTERFACE_MAXRATE=${INTERFACE_MAXRATE}" >> .env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -144,7 +144,7 @@ services:
       - -registration-url=file:///autonode/registration.json
       - -heartbeat-url=wss://${LOCATE_URL}/v2/platform/heartbeat-jwt
       - -api-key=${API_KEY}
-      - -token-exchange-url=https://auth.${PROJECT}.measurementlab.net/v0/token/autojoin
+      - -token-exchange-url=https://${AUTH_URL}/v0/token/autojoin
       - -services=ndt/ndt7=ws:///ndt/v7/download,ws:///ndt/v7/upload,wss:///ndt/v7/download,wss:///ndt/v7/upload
     network_mode: host
 

--- a/env
+++ b/env
@@ -90,3 +90,4 @@ TYPE=
 
 PROJECT=mlab-autojoin
 LOCATE_URL=locate.measurementlab.net
+AUTH_URL=auth.mlab-oti.measurementlab.net


### PR DESCRIPTION
## Summary
- Add `AUTH_URL` environment variable to decouple auth URL from `PROJECT`
- Update heartbeat's `-token-exchange-url` to use `AUTH_URL`
- Default value: `auth.mlab-oti.measurementlab.net`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/44)
<!-- Reviewable:end -->
