### PR TITLE
chore(autonode): bump ndt-server to v0.25.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   # ndt-server is the public facing measurement service. Only ndt7 is enabled.
   ndt-server:
-    image: measurementlab/ndt-server:v0.23.1
+    image: measurementlab/ndt-server:v0.25.2
     profiles: [ndt]
     network_mode: host
     cap_add:
@@ -304,7 +304,7 @@ services:
   # compatible with upstream schemas and safe to upload.
   generate-schemas-ndt7:
     network_mode: host
-    image: measurementlab/ndt-server:v0.22.0
+    image: measurementlab/ndt-server:v0.25.2
     volumes:
       - ./schemas:/schemas
     entrypoint:


### PR DESCRIPTION
## Summary

Bump both `ndt-server` images in autonode to `v0.25.2`:
- **`ndt-server`** (public measurement service): brought up to the current release.
- **`generate-schemas-ndt7`**: produces the ndt7 BigQuery schema with `TCPInfo`/`Measurement` fields in the corrected order, matching the legacy ndt7 table (see m-lab/ndt-server#433).

The corrected schema was deployed to GCS directly as the immediate fix. Bumping `generate-schemas-ndt7` ensures **future** schema regenerations preserve the corrected field order: jostler's compatibility check is order-blind, so it only re-uploads the schema when a field is *added*, at which point it builds it from `generate-schemas`.

Part of the fix for m-lab/etl-schema#195.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/46)
<!-- Reviewable:end -->
