### PR TITLE
feat: add reverse traceroute vantage point support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+env.local

--- a/README.md
+++ b/README.md
@@ -3,3 +3,96 @@
 Documentation on how to set up a host-managed M-Lab server is located in [the
 Wiki of this
 repository](https://github.com/m-lab/autonode/wiki/Host%E2%80%90managed-Deployments).
+
+## Deploying
+
+Copy the `env` template and fill in your values:
+
+```bash
+cp env env.local
+# edit env.local with your ORGANIZATION, API_KEY, IPV4, etc.
+```
+
+Start the full stack (NDT + reverse traceroute):
+
+```bash
+docker compose --env-file env.local --profile ndt --profile revtr up -d
+```
+
+Start without reverse traceroute:
+
+```bash
+docker compose --env-file env.local --profile ndt up -d
+```
+
+**Tip:** to avoid repeating the flags on every invocation, create a `.env` file
+(gitignored) in this directory:
+
+```bash
+cat > .env << 'EOF'
+COMPOSE_PROFILES=ndt,revtr
+EOF
+# Then simply:
+docker compose --env-file env.local up -d
+```
+
+## Reverse Traceroute
+
+When the `revtr` profile is active, two additional containers start automatically
+from their published images — no extra repositories or build steps required:
+
+- **revtrvp** ([ghcr.io/neu-sns/revtrvp](https://github.com/NEU-SNS/revtrvp)) —
+  a scamper-based vantage point that runs on ndt-server's public IP and executes
+  spoofed-ICMP probing instructions from the revtr controller.
+- **revtr-sidecar** ([ghcr.io/neu-sns/revtr-sidecar](https://github.com/NEU-SNS/revtr-sidecar)) —
+  watches completed NDT connections and asks the revtr controller to run a reverse
+  traceroute from each client back to this node.
+
+### Configuration
+
+Add the following to your `env.local`:
+
+```bash
+# API key for the reverse traceroute gRPC API (obtain from the revtr team).
+REVTR_API_KEY=
+
+# Hostname and port of the reverse traceroute API server.
+REVTR_HOSTNAME=revtr.ccs.neu.edu
+REVTR_GRPC_PORT=9999
+
+# Sampling rate: 1 out of every N NDT connections triggers a reverse traceroute.
+# Use 1 to trigger on every connection.
+REVTR_SAMPLING=1
+```
+
+Place a `plvp.config` file in `./revtrvp/plvp.config` (relative to this
+directory). Minimal example:
+
+```yaml
+local:
+    interface: <your-interface>   # e.g. eth0
+    host: 'plcontroller.revtr.ccs.neu.edu'
+    port: 4380
+scamper:
+    binpath: '/usr/local/bin/scamper'
+    port: 4381
+```
+
+### ICMP identifier partitioning (optional)
+
+When revtrvp and traceroute-caller run on the same host they both spawn scamper
+instances that share the host network namespace. To prevent them from picking the
+same ICMP identifier, build the patched scamper binary and configure the ID space
+partitioning in `env.local`:
+
+```bash
+# Use the patched binary built from the scamper ICMP-ID partitioning patch.
+SCAMPER_BIN=/usr/local/bin/scamper-anticollision
+
+# traceroute-caller takes the upper half of the ID space; revtrvp takes the lower.
+SCAMPER_ICMP_ID_BASE=32768
+SCAMPER_ICMP_ID_RANGE=32768
+```
+
+Without this, both instances use the default `getpid() & 0xffff` identifier
+selection, which may result in occasional ICMP probe collisions.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,13 @@
+# M-Lab autonode deployment.
+#
+# Run from this directory:
+#
+#   # NDT + reverse traceroute (recommended):
+#   docker compose --env-file env.local --profile ndt --profile revtr up -d
+#
+#   # NDT only (no reverse traceroute):
+#   docker compose --env-file env.local --profile ndt up -d
+
 services:
   # Register this node with the Autojoin API. A successful registration will
   # assign a DNS name for this node based on the public IPs, their ASN,
@@ -238,6 +248,8 @@ services:
       - ./resultsdir:/resultsdir
       - ./schemas:/schemas
       - ./metadata:/metadata
+      # Mount the host scamper binary; select it via SCAMPER_BIN in the env file.
+      - /usr/local/bin/scamper:/usr/local/bin/scamper-anticollision:ro
     depends_on:
       generate-schemas-traceroute:
         condition: service_completed_successfully
@@ -245,6 +257,11 @@ services:
         condition: service_healthy
       ndt-server:
         condition: service_healthy
+    environment:
+      # Partition the ICMP identifier space so traceroute-caller's scamper
+      # does not collide with revtrvp's scamper (see SCAMPER_ICMP_ID_* in env).
+      - SCAMPER_ICMP_ID_BASE=${SCAMPER_ICMP_ID_BASE:-}
+      - SCAMPER_ICMP_ID_RANGE=${SCAMPER_ICMP_ID_RANGE:-}
     pull_policy: always
     restart: always
     configs:
@@ -266,6 +283,7 @@ services:
       - -anonymize.ip=none
       - -scamper.trace-type=regular
       - -output.format=json
+      - -scamper.bin=${SCAMPER_BIN}
 
   node-exporter:
     image: quay.io/prometheus/node-exporter:v1.9.0
@@ -333,6 +351,59 @@ services:
   check-bbr:
     image: bash:latest
     command: ["sh", "-c", "lsmod | grep tcp_bbr"]
+
+  # ── Reverse traceroute (--profile revtr) ────────────────────────────────────
+  #
+  # revtrvp is a scamper-based vantage point that listens on ndt-server's public
+  # IP (via shared network namespace) and executes spoofed-ICMP probing
+  # instructions from the revtr controller.
+  #
+  # revtr-sidecar watches completed NDT connections and asks the revtr controller
+  # to run a reverse traceroute from each client back to this node.
+  #
+  # Both services require REVTR_* variables to be set in the env file.
+  revtrvp:
+    image: ghcr.io/neu-sns/revtrvp:latest
+    profiles: [revtr]
+    restart: unless-stopped
+    # Share ndt-server's network namespace so revtrvp listens on the same public
+    # IP that clients used for the speedtest.
+    network_mode: "service:ndt-server"
+    cap_add:
+      - NET_RAW
+    volumes:
+      - ./revtrvp/plvp.config:/plvp.config:ro
+    environment:
+      # Allocate the lower half of the ICMP identifier space [0, 32768) to
+      # revtrvp's scamper; traceroute-caller takes the upper half (see env).
+      - SCAMPER_ICMP_ID_BASE=0
+      - SCAMPER_ICMP_ID_RANGE=32768
+    command: ["/server.crt", "/plvp.config", "-loglevel", "info"]
+    depends_on:
+      ndt-server:
+        condition: service_healthy
+
+  revtr-sidecar:
+    image: ghcr.io/neu-sns/revtr-sidecar:latest
+    profiles: [revtr]
+    restart: unless-stopped
+    network_mode: "service:ndt-server"
+    volumes:
+      - ./schemas/events.sock:/schemas/events.sock:ro
+    environment:
+      # flagx.ArgsFromEnv maps flag names to env vars: revtr.APIKey→REVTR_APIKEY,
+      # revtr.hostname→REVTR_HOSTNAME, revtr.grpcPort→REVTR_GRPCPORT,
+      # revtr.sampling→REVTR_SAMPLING, tcpinfo.eventsocket→TCPINFO_EVENTSOCKET.
+      - REVTR_HOSTNAME=${REVTR_HOSTNAME}
+      - REVTR_APIKEY=${REVTR_API_KEY}
+      - REVTR_GRPCPORT=${REVTR_GRPC_PORT}
+      - REVTR_SAMPLING=${REVTR_SAMPLING:-1}
+      - TCPINFO_EVENTSOCKET=/schemas/events.sock
+    depends_on:
+      ndt-server:
+        condition: service_healthy
+      revtrvp:
+        condition: service_started
 
 configs:
   locate-verify-key:

--- a/env
+++ b/env
@@ -85,9 +85,54 @@ IPV6=
 # bare-metal machine dedicated to M-Lab, or a VM?
 TYPE=
 
+# ### Reverse Traceroute sidecar configuration ###
+
+# REVTR_API_KEY is the API key used to call the reverse traceroute gRPC API.
+REVTR_API_KEY=
+
+# REVTR_HOSTNAME is the hostname of the reverse traceroute API server.
+REVTR_HOSTNAME=revtr.ccs.neu.edu
+
+# REVTR_GRPC_PORT is the gRPC port of the reverse traceroute API.
+# Use 9998 for a debug/insecure connection (no TLS), any other port uses TLS.
+REVTR_GRPC_PORT=9999
+
+# REVTR_SAMPLING controls the sampling rate passed to the revtr-sidecar as
+# -revtr.sampling: only 1 out of every N NDT connections triggers a reverse
+# traceroute. Must be > 0. Use 1 to trigger on every connection.
+REVTR_SAMPLING=1
+
+# SCAMPER_BIN selects which scamper binary traceroute-caller uses.
+#
+# /usr/local/bin/scamper          — bundled binary inside the container image
+#                                   (default; no host binary required)
+#
+# /usr/local/bin/scamper-anticollision — host binary mounted from the machine
+#                                   running this compose stack; built with the
+#                                   ICMP-ID space partitioning fix. Use this
+#                                   when multiple scamper instances run on the
+#                                   same host (e.g. alongside revtrvp) so that
+#                                   each gets a non-overlapping ICMP ID range.
+#                                   Requires /usr/local/bin/scamper to exist on
+#                                   the host (the volume mount in
+#                                   docker-compose.yml exposes it inside the
+#                                   container at the path above).
+# SCAMPER_BIN=/usr/local/bin/scamper
+SCAMPER_BIN=/usr/local/bin/scamper
+
+# SCAMPER_ICMP_ID_BASE and SCAMPER_ICMP_ID_RANGE partition the 16-bit ICMP
+# identifier space between scamper instances that share the host network
+# namespace (traceroute-caller and revtrvp both run on the same IP).
+# traceroute-caller takes the upper half; revtrvp takes the lower half.
+# These values are passed to scamper via the environment and only take effect
+# when using the patched scamper-anticollision binary (SCAMPER_BIN above).
+SCAMPER_ICMP_ID_BASE=32768
+SCAMPER_ICMP_ID_RANGE=32768
+
 # ### Static configuration variables ###
 # ###    Do NOT change these.        ###
 
 PROJECT=mlab-autojoin
 LOCATE_URL=locate.measurementlab.net
 AUTH_URL=auth.mlab-oti.measurementlab.net
+


### PR DESCRIPTION
## Summary

- Adds `revtrvp` and `revtr-sidecar` services to `docker-compose.yml` under a `revtr` profile, pulling from published images (`ghcr.io/neu-sns/revtrvp` and `ghcr.io/neu-sns/revtr-sidecar`) — no extra repos or build steps needed.
- Both services share `ndt-server`'s network namespace (`network_mode: "service:ndt-server"`) so the vantage point listens on the same public IP clients used for NDT.
- Documents ICMP identifier space partitioning (`SCAMPER_ICMP_ID_BASE` / `SCAMPER_ICMP_ID_RANGE`) to prevent collisions between `traceroute-caller`'s scamper and `revtrvp`'s scamper when running on the same host.
- Adds `REVTR_*` variables and `SCAMPER_BIN` / `SCAMPER_ICMP_ID_*` to the `env` template with comments.
- Updates `README.md` with deploy commands, revtr service descriptions, and configuration reference.
- Adds `.gitignore` entries for `.env` and `env.local`.

## Deploy

```bash
# NDT + reverse traceroute (default):
docker compose --env-file env.local --profile ndt --profile revtr up -d

# NDT only:
docker compose --env-file env.local --profile ndt up -d
```

## Test plan

- [ ] Copy `env` to `env.local`, fill in `ORGANIZATION`, `API_KEY`, `IPV4`, `IATA`, `REVTR_API_KEY`
- [ ] Place `revtrvp/plvp.config` with correct interface and controller address
- [ ] Run `docker compose --env-file env.local --profile ndt --profile revtr up -d`
- [ ] Verify `revtrvp` and `revtr-sidecar` containers start and attach to `ndt-server`'s network
- [ ] Run an NDT test from a remote client; confirm `revtr-sidecar` logs show a reverse traceroute being triggered
- [ ] Confirm NDT-only deploy (`--profile ndt` without `--profile revtr`) starts cleanly without revtr containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/47)
<!-- Reviewable:end -->
