### PR TITLE
chore(autonode): bump ndt-server to v0.25.3

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
 
   # ndt-server is the public facing measurement service. Only ndt7 is enabled.
   ndt-server:
-    image: measurementlab/ndt-server:v0.25.2
+    image: measurementlab/ndt-server:v0.25.3
     profiles: [ndt]
     network_mode: host
     cap_add:
@@ -304,7 +304,7 @@ services:
   # compatible with upstream schemas and safe to upload.
   generate-schemas-ndt7:
     network_mode: host
-    image: measurementlab/ndt-server:v0.25.2
+    image: measurementlab/ndt-server:v0.25.3
     volumes:
       - ./schemas:/schemas
     entrypoint:


### PR DESCRIPTION
Bumps ndt-server to v0.25.3, which updates generate-schemas to emit the current ndt7 schema (including ConnectionInfo.StartTime). No server-side changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/autonode/48)
<!-- Reviewable:end -->
